### PR TITLE
Fix Navbar links for product routes

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -129,20 +129,24 @@ export const Navbar: React.FC = () => {
                     </Link>
                   </li>
                   <li>
-                  <Link href={`${basePath}/products/leading-virtually`}>Lede virtuelt</Link>
+                    <Link href={`${basePath}/products/leading-virtually`}>
+                      Lede virtuelt
+                    </Link>
                   </li>
                   <li>
-                    <Link href={`${basePath}/service`}>
+                    <Link href={`${basePath}/products/service`}>
                       Legendarisk kundeservice
                     </Link>
                   </li>
                   <li>
-                    <Link href={`${basePath}/optimal-motivation`}>
+                    <Link href={`${basePath}/products/optimal-motivation`}>
                       Optimal motivasjon
                     </Link>
                   </li>
                   <li>
-                    <Link href={`${basePath}/self-leadership`}>Selvledelse</Link>
+                    <Link href={`${basePath}/products/self-leadership`}>
+                      Selvledelse
+                    </Link>
                   </li>
                   <li>
                     <Link href={`${basePath}/products/team-leadership`}>


### PR DESCRIPTION
Some of the links were missing the `/products` directory, this should fix that.